### PR TITLE
Add weekly progress tracking with overexposure calculation

### DIFF
--- a/Sunshade/Views/DailyProgressCard.swift
+++ b/Sunshade/Views/DailyProgressCard.swift
@@ -10,7 +10,7 @@ struct DailyProgressCard: View {
                     .font(.title2)
                     .foregroundColor(AppColors.info)
                 
-                Text("Today's Progress")
+                Text("Weekly Progress")
                     .font(.headline)
                     .fontWeight(.semibold)
                     .foregroundColor(AppColors.textPrimary)
@@ -20,7 +20,7 @@ struct DailyProgressCard: View {
             
             HStack {
                 VStack {
-                    Text("\(viewModel.sessionsToday)")
+                    Text("\(viewModel.sessionsThisWeek)")
                         .font(.title)
                         .fontWeight(.bold)
                         .foregroundColor(AppColors.primary)
@@ -33,7 +33,7 @@ struct DailyProgressCard: View {
                 Spacer()
                 
                 VStack {
-                    Text(viewModel.totalExposureToday)
+                    Text(viewModel.totalExposureThisWeek)
                         .font(.title)
                         .fontWeight(.bold)
                         .foregroundColor(AppColors.accent)
@@ -46,12 +46,12 @@ struct DailyProgressCard: View {
                 Spacer()
                 
                 VStack {
-                    Text("75%")
+                    Text(viewModel.overExposurePercentage)
                         .font(.title)
                         .fontWeight(.bold)
-                        .foregroundColor(AppColors.success)
+                        .foregroundColor(viewModel.overExposurePercentage == "0%" ? AppColors.success : AppColors.warning)
                     
-                    Text("Daily Goal")
+                    Text("Over-exposure")
                         .font(.caption)
                         .foregroundColor(AppColors.textSecondary)
                 }


### PR DESCRIPTION
## Summary
• Updated DailyProgressCard to display weekly metrics instead of daily
• Added weekly sessions count and total exposure time calculations 
• Implemented overexposure percentage based on UV index and safe exposure limits
• Added exposure log observer to update UI when sessions change

## Test plan
- [ ] Verify weekly sessions count displays correctly
- [ ] Confirm total weekly exposure time shows proper format (hours/minutes)
- [ ] Test overexposure percentage calculation with different UV levels
- [ ] Ensure UI updates when exposure sessions are added/removed

🤖 Generated with [Claude Code](https://claude.ai/code)