### PR TITLE
Add conditional UV warning display based on UV index threshold

### DIFF
--- a/Sunshade/Views/UVIndexCard.swift
+++ b/Sunshade/Views/UVIndexCard.swift
@@ -72,21 +72,23 @@ struct UVIndexCard: View {
             .background(AppColors.info.opacity(0.1))
             .cornerRadius(12)
             
-            HStack(spacing: 12) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundColor(AppColors.warning)
-                    .font(.title3)
-                
-                Text("High UV levels detected. Use sun protection.")
-                    .font(.subheadline)
-                    .foregroundColor(AppColors.textSecondary)
-                    .multilineTextAlignment(.leading)
-                
-                Spacer()
+            if viewModel.currentUVIndex >= 6 {
+                HStack(spacing: 12) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(AppColors.warning)
+                        .font(.title3)
+                    
+                    Text("High UV levels detected. Use sun protection.")
+                        .font(.subheadline)
+                        .foregroundColor(AppColors.textSecondary)
+                        .multilineTextAlignment(.leading)
+                    
+                    Spacer()
+                }
+                .padding(16)
+                .background(AppColors.warning.opacity(0.1))
+                .cornerRadius(12)
             }
-            .padding(16)
-            .background(AppColors.warning.opacity(0.1))
-            .cornerRadius(12)
         }
         .padding(24)
         .background(Color.white)


### PR DESCRIPTION
## Summary
- Add conditional visibility for "High UV levels detected" warning bubble
- Warning now only displays when UV index >= 6 (High level)
- Improved user experience by reducing visual clutter during low/moderate UV conditions
- Maintained consistent bubble styling with SafetyCard design

## Test plan
- [ ] Verify warning bubble appears when UV index is 6 or higher
- [ ] Verify warning bubble is hidden when UV index is below 6
- [ ] Confirm bubble styling matches SafetyCard bubbles
- [ ] Test with various UV index values to ensure threshold works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)