### PR TITLE
Connect Privacy Notice navigation to PrivacyNoticeView

### DIFF
--- a/Sunshade/Views/MainContentView.swift
+++ b/Sunshade/Views/MainContentView.swift
@@ -51,6 +51,7 @@ struct AuthenticatedProfileView: View {
     @EnvironmentObject var authManager: AuthenticationManager
     @State private var showingSignOutAlert = false
     @State private var showingAccountSettings = false
+    @State private var showingPrivacySettings = false
     
     var body: some View {
         NavigationView {
@@ -111,8 +112,8 @@ struct AuthenticatedProfileView: View {
                     
                     ProfileActionRow(
                         icon: "shield.checkerboard",
-                        title: "Privacy Settings",
-                        action: { /* Privacy */ }
+                        title: "Privacy Notice",
+                        action: { showingPrivacySettings = true }
                     )
                     
                     ProfileActionRow(
@@ -155,6 +156,9 @@ struct AuthenticatedProfileView: View {
         }
         .sheet(isPresented: $showingAccountSettings) {
             AccountSettingsView()
+        }
+        .sheet(isPresented: $showingPrivacySettings) {
+            PrivacyNoticeView()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Connect "Privacy Notice" link in profile view to existing PrivacyNoticeView
- Add proper navigation with sheet presentation for privacy policy display
- Rename link from "Privacy Settings" to "Privacy Notice" for better clarity
- Implement state management for modal presentation

## Test plan
- [ ] Verify "Privacy Notice" link appears in profile view
- [ ] Confirm tapping the link opens PrivacyNoticeView in a modal sheet
- [ ] Test that the privacy notice displays all content correctly
- [ ] Verify modal can be dismissed to return to profile view
- [ ] Check that the link text reads "Privacy Notice" instead of "Privacy Settings"

🤖 Generated with [Claude Code](https://claude.ai/code)