### PR TITLE
Rebrand app from Sunshade to SunshAid

### DIFF
--- a/Sunshade.xcodeproj/project.pbxproj
+++ b/Sunshade.xcodeproj/project.pbxproj
@@ -399,10 +399,10 @@
 				DEVELOPMENT_TEAM = 389Y5DY6GV;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = Sunshade;
+				INFOPLIST_KEY_CFBundleDisplayName = SunshAid;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
-				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Sunshade needs access to your location to provide accurate UV index and weather information for your area.";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Sunshade needs access to your location to provide accurate UV index and weather information for your area.";
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "SunshAid needs access to your location to provide accurate UV index and weather information for your area.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "SunshAid needs access to your location to provide accurate UV index and weather information for your area.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -431,10 +431,10 @@
 				DEVELOPMENT_TEAM = 389Y5DY6GV;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = Sunshade;
+				INFOPLIST_KEY_CFBundleDisplayName = SunshAid;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
-				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Sunshade needs access to your location to provide accurate UV index and weather information for your area.";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Sunshade needs access to your location to provide accurate UV index and weather information for your area.";
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "SunshAid needs access to your location to provide accurate UV index and weather information for your area.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "SunshAid needs access to your location to provide accurate UV index and weather information for your area.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Sunshade/Views/AuthenticationView.swift
+++ b/Sunshade/Views/AuthenticationView.swift
@@ -18,7 +18,7 @@ struct AuthenticationView: View {
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 100, height: 100)
                     
-                    Text("Welcome to Sunshade")
+                    Text("Welcome to SunshAid")
                         .font(.largeTitle)
                         .fontWeight(.bold)
                         .foregroundColor(AppColors.textPrimary)

--- a/Sunshade/Views/DashboardView.swift
+++ b/Sunshade/Views/DashboardView.swift
@@ -17,7 +17,7 @@ struct DashboardView: View {
                 .padding(.vertical)
             }
             .background(AppColors.backgroundPrimary)
-            .navigationTitle("Sunshade")
+            .navigationTitle("SunshAid")
             .navigationBarTitleDisplayMode(.large)
             .refreshable {
                 await viewModel.refreshData()

--- a/Sunshade/Views/HelpSupportView.swift
+++ b/Sunshade/Views/HelpSupportView.swift
@@ -142,9 +142,9 @@ struct HelpSupportView: View {
         .sheet(isPresented: $showingMailComposer) {
             MailComposeView(
                 recipients: ["sunshadeapp@gmail.com"],
-                subject: "Sunshade App Support",
+                subject: "SunshAid App Support",
                 messageBody: """
-                Hi Sunshade Support Team,
+                Hi SunshAid Support Team,
                 
                 App Version: 1.0.0
                 Device: \(UIDevice.current.model)

--- a/Sunshade/Views/LegalDisclaimerView.swift
+++ b/Sunshade/Views/LegalDisclaimerView.swift
@@ -13,19 +13,19 @@ struct LegalDisclaimerView: View {
                     
                     Group {
                         SectionView(title: "Medical Disclaimer") {
-                            Text("IMPORTANT: Sunshade is not a medical device and should not be used as a substitute for professional medical advice, diagnosis, or treatment. Always consult with a qualified healthcare provider regarding sun exposure recommendations, especially if you have skin conditions or medical concerns.")
+                            Text("IMPORTANT: SunshAid is not a medical device and should not be used as a substitute for professional medical advice, diagnosis, or treatment. Always consult with a qualified healthcare provider regarding sun exposure recommendations, especially if you have skin conditions or medical concerns.")
                         }
                         
                         SectionView(title: "Accuracy of Information") {
-                            Text("While we strive to provide accurate UV index and weather information, Sunshade relies on third-party data sources. We cannot guarantee the accuracy, completeness, or timeliness of this information. Weather conditions can change rapidly and may not be reflected immediately in the app.")
+                            Text("While we strive to provide accurate UV index and weather information, SunshAid relies on third-party data sources. We cannot guarantee the accuracy, completeness, or timeliness of this information. Weather conditions can change rapidly and may not be reflected immediately in the app.")
                         }
                         
                         SectionView(title: "No Warranty") {
-                            Text("Sunshade is provided 'as is' without any warranty of any kind, either express or implied. We do not warrant that the app will be error-free, uninterrupted, or meet your specific requirements.")
+                            Text("SunshAid is provided 'as is' without any warranty of any kind, either express or implied. We do not warrant that the app will be error-free, uninterrupted, or meet your specific requirements.")
                         }
                         
                         SectionView(title: "Limitation of Liability") {
-                            Text("In no event shall the developers of Sunshade be liable for any direct, indirect, incidental, special, or consequential damages resulting from the use or inability to use this application, including but not limited to sunburn, skin damage, or other health issues.")
+                            Text("In no event shall the developers of SunshAid be liable for any direct, indirect, incidental, special, or consequential damages resulting from the use or inability to use this application, including but not limited to sunburn, skin damage, or other health issues.")
                         }
                         
                         SectionView(title: "Personal Responsibility") {
@@ -33,11 +33,11 @@ struct LegalDisclaimerView: View {
                         }
                         
                         SectionView(title: "Third-Party Content") {
-                            Text("Sunshade may include information or links to third-party content. We are not responsible for the accuracy, completeness, or reliability of such content. Any reliance on third-party information is at your own risk.")
+                            Text("SunshAid may include information or links to third-party content. We are not responsible for the accuracy, completeness, or reliability of such content. Any reliance on third-party information is at your own risk.")
                         }
                         
                         SectionView(title: "Emergency Situations") {
-                            Text("Sunshade is not designed for emergency situations. In case of severe sunburn, heat-related illness, or other medical emergencies, seek immediate medical attention. Do not rely on this app for emergency medical guidance.")
+                            Text("SunshAid is not designed for emergency situations. In case of severe sunburn, heat-related illness, or other medical emergencies, seek immediate medical attention. Do not rely on this app for emergency medical guidance.")
                         }
                         
                         SectionView(title: "Geographic Limitations") {
@@ -49,7 +49,7 @@ struct LegalDisclaimerView: View {
                         }
                         
                         SectionView(title: "Indemnification") {
-                            Text("By using Sunshade, you agree to indemnify and hold harmless the developers from any claims, damages, or expenses arising from your use of the app or your violation of these terms.")
+                            Text("By using SunshAid, you agree to indemnify and hold harmless the developers from any claims, damages, or expenses arising from your use of the app or your violation of these terms.")
                         }
                     }
                     

--- a/Sunshade/Views/LicenseTermsView.swift
+++ b/Sunshade/Views/LicenseTermsView.swift
@@ -15,15 +15,15 @@ struct LicenseTermsView: View {
                     
                     Group {
                         SectionView(title: "1. Acceptance of Terms") {
-                            Text("By downloading, installing, or using the Sunshade application, you agree to be bound by these Terms of Use. If you do not agree to these terms, please do not use the application.")
+                            Text("By downloading, installing, or using the SunshAid application, you agree to be bound by these Terms of Use. If you do not agree to these terms, please do not use the application.")
                         }
                         
                         SectionView(title: "2. License Grant") {
-                            Text("Sunshade grants you a limited, non-exclusive, non-transferable license to use this application for personal, non-commercial purposes in accordance with these terms.")
+                            Text("SunshAid grants you a limited, non-exclusive, non-transferable license to use this application for personal, non-commercial purposes in accordance with these terms.")
                         }
                         
                         SectionView(title: "3. Permitted Use") {
-                            Text("You may use Sunshade for:\n• Personal UV exposure monitoring\n• Educational purposes related to sun safety\n• Tracking your sun exposure habits\n• Accessing weather and UV index information")
+                            Text("You may use SunshAid for:\n• Personal UV exposure monitoring\n• Educational purposes related to sun safety\n• Tracking your sun exposure habits\n• Accessing weather and UV index information")
                         }
                         
                         SectionView(title: "4. Prohibited Use") {
@@ -31,7 +31,7 @@ struct LicenseTermsView: View {
                         }
                         
                         SectionView(title: "5. Intellectual Property") {
-                            Text("All content, features, and functionality of Sunshade are owned by the developers and are protected by international copyright, trademark, and other intellectual property laws.")
+                            Text("All content, features, and functionality of SunshAid are owned by the developers and are protected by international copyright, trademark, and other intellectual property laws.")
                         }
                         
                         SectionView(title: "6. Updates and Modifications") {

--- a/Sunshade/Views/PrivacyNoticeView.swift
+++ b/Sunshade/Views/PrivacyNoticeView.swift
@@ -15,7 +15,7 @@ struct PrivacyNoticeView: View {
                     
                     Group {
                         SectionView(title: "Information We Collect") {
-                            Text("Sunshade may collect the following information:\n• Location data (with your permission) for UV index information\n• Usage patterns and app interactions\n• Device information for optimal app performance\n• Sun exposure session data (stored locally on your device)")
+                            Text("SunshAid may collect the following information:\n• Location data (with your permission) for UV index information\n• Usage patterns and app interactions\n• Device information for optimal app performance\n• Sun exposure session data (stored locally on your device)")
                         }
                         
                         SectionView(title: "How We Use Your Information") {
@@ -31,7 +31,7 @@ struct PrivacyNoticeView: View {
                         }
                         
                         SectionView(title: "Third-Party Services") {
-                            Text("Sunshade uses Apple's WeatherKit to provide UV index information. Weather data is accessed through your Apple Developer account with no additional APIs or third-party services required.")
+                            Text("SunshAid uses Apple's WeatherKit to provide UV index information. Weather data is accessed through your Apple Developer account with no additional APIs or third-party services required.")
                         }
                         
                         SectionView(title: "Data Retention") {
@@ -43,7 +43,7 @@ struct PrivacyNoticeView: View {
                         }
                         
                         SectionView(title: "Children's Privacy") {
-                            Text("Sunshade is not intended for children under 13. We do not knowingly collect personal information from children under 13. If you believe we have collected such information, please contact us immediately.")
+                            Text("SunshAid is not intended for children under 13. We do not knowingly collect personal information from children under 13. If you believe we have collected such information, please contact us immediately.")
                         }
                         
                         SectionView(title: "Changes to This Privacy Notice") {

--- a/Sunshade/Views/ProfileView.swift
+++ b/Sunshade/Views/ProfileView.swift
@@ -80,7 +80,7 @@ struct ProfileView: View {
                             }
                         }
                         
-                        Text("Sunshade User")
+                        Text("SunshAid User")
                             .font(.subheadline)
                             .foregroundColor(AppColors.textSecondary)
                     }


### PR DESCRIPTION
## Summary
- Rebranded the application from "Sunshade" to "SunshAid" across all user-facing views
- Updated app display name for system integrations (Sign in with Apple, location permissions)
- Modified all references in legal documents and support communications

## Changes Made
- **App Views**: Updated navigation titles, welcome messages, and user labels
- **Xcode Project**: Changed `CFBundleDisplayName` from "Sunshade" to "SunshAid"
- **Legal Documents**: Updated references in Privacy Notice, License Terms, and Legal Disclaimer
- **Support**: Modified email subjects and greetings in Help & Support view
- **System Permissions**: Updated location permission descriptions

## Test Plan
- [ ] Build and run the app to verify all UI text displays "SunshAid"
- [ ] Test Sign in with Apple flow to confirm dialog shows "SunshAid"
- [ ] Check location permission prompt displays updated text
- [ ] Review all legal documents for correct branding
- [ ] Verify help/support email templates use new name

🤖 Generated with [Claude Code](https://claude.ai/code)