### PR TITLE
Add Apple Weather attribution to comply with App Store requirements

### DIFF
--- a/Sunshade/Views/ProfileView.swift
+++ b/Sunshade/Views/ProfileView.swift
@@ -202,6 +202,15 @@ struct ProfileView: View {
                                 showingLegalDisclaimer = true
                             }
                         )
+                        
+                        Divider()
+                            .background(AppColors.backgroundSecondary)
+                        
+                        LegalMenuItem(
+                            icon: "apple.logo",
+                            title: "Weather Attribution",
+                            url: URL(string: "https://weatherkit.apple.com/legal-attribution.html")
+                        )
                     }
                 }
                 .padding()
@@ -297,30 +306,57 @@ struct StatItem: View {
 struct LegalMenuItem: View {
     let icon: String
     let title: String
-    let action: () -> Void
+    var action: (() -> Void)?
+    var url: URL?
     
     var body: some View {
-        Button(action: action) {
-            HStack(spacing: 12) {
-                Image(systemName: icon)
-                    .foregroundColor(AppColors.primary)
-                    .font(.system(size: 18))
-                    .frame(width: 24, height: 24)
-                
-                Text(title)
-                    .font(.body)
-                    .foregroundColor(AppColors.textPrimary)
-                    .multilineTextAlignment(.leading)
-                
-                Spacer()
-                
-                Image(systemName: "chevron.right")
-                    .foregroundColor(AppColors.textMuted)
-                    .font(.system(size: 14))
+        Group {
+            if let url = url {
+                Link(destination: url) {
+                    HStack(spacing: 12) {
+                        Image(systemName: icon)
+                            .foregroundColor(AppColors.primary)
+                            .font(.system(size: 18))
+                            .frame(width: 24, height: 24)
+                        
+                        Text(title)
+                            .font(.body)
+                            .foregroundColor(AppColors.textPrimary)
+                            .multilineTextAlignment(.leading)
+                        
+                        Spacer()
+                        
+                        Image(systemName: "arrow.up.right.square")
+                            .foregroundColor(AppColors.textMuted)
+                            .font(.system(size: 14))
+                    }
+                    .padding(.vertical, 8)
+                    .contentShape(Rectangle())
+                }
+            } else if let action = action {
+                Button(action: action) {
+                    HStack(spacing: 12) {
+                        Image(systemName: icon)
+                            .foregroundColor(AppColors.primary)
+                            .font(.system(size: 18))
+                            .frame(width: 24, height: 24)
+                        
+                        Text(title)
+                            .font(.body)
+                            .foregroundColor(AppColors.textPrimary)
+                            .multilineTextAlignment(.leading)
+                        
+                        Spacer()
+                        
+                        Image(systemName: "chevron.right")
+                            .foregroundColor(AppColors.textMuted)
+                            .font(.system(size: 14))
+                    }
+                    .padding(.vertical, 8)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(PlainButtonStyle())
             }
-            .padding(.vertical, 8)
-            .contentShape(Rectangle())
         }
-        .buttonStyle(PlainButtonStyle())
     }
 }

--- a/Sunshade/Views/UVIndexCard.swift
+++ b/Sunshade/Views/UVIndexCard.swift
@@ -120,6 +120,12 @@ struct UVIndexCard: View {
                     .background(AppColors.warning.opacity(0.1))
                     .cornerRadius(12)
                 }
+                
+                // Apple Weather Attribution
+                HStack {
+                    Spacer()
+                    CompactWeatherAttributionView()
+                }
             }
         }
         .padding(24)

--- a/Sunshade/Views/WeatherAttributionView.swift
+++ b/Sunshade/Views/WeatherAttributionView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct WeatherAttributionView: View {
+    var body: some View {
+        Link(destination: URL(string: "https://weatherkit.apple.com/legal-attribution.html")!) {
+            HStack(spacing: 4) {
+                Image(systemName: "apple.logo")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                
+                Text("Weather")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.secondary.opacity(0.1))
+            .cornerRadius(6)
+        }
+    }
+}
+
+struct CompactWeatherAttributionView: View {
+    var body: some View {
+        Link(destination: URL(string: "https://weatherkit.apple.com/legal-attribution.html")!) {
+            HStack(spacing: 2) {
+                Image(systemName: "apple.logo")
+                    .font(.caption2)
+                
+                Text("Weather")
+                    .font(.caption2)
+            }
+            .foregroundColor(.secondary.opacity(0.8))
+        }
+    }
+}

--- a/Sunshade/Views/WeatherCard.swift
+++ b/Sunshade/Views/WeatherCard.swift
@@ -79,10 +79,16 @@ struct WeatherCard: View {
                         .padding(.horizontal, 20)
                     
                     VStack(spacing: 12) {
-                        Text("5-Day Forecast")
-                            .font(.headline)
-                            .foregroundColor(AppColors.textPrimary)
-                            .padding(.top, 16)
+                        HStack {
+                            Text("5-Day Forecast")
+                                .font(.headline)
+                                .foregroundColor(AppColors.textPrimary)
+                            
+                            Spacer()
+                            
+                            WeatherAttributionView()
+                        }
+                        .padding(.top, 16)
                         
                         ForEach(Array(viewModel.forecast.enumerated()), id: \.offset) { index, day in
                             ForecastRowView(day: day, isToday: index == 0)


### PR DESCRIPTION
## Summary
- Added Apple Weather attribution throughout the app to comply with App Store Review Guideline 5.2.5
- Addresses review feedback requiring clear display of the Apple Weather trademark for apps using WeatherKit
- Attribution includes Apple logo (🍎) + "Weather" text with link to legal attribution page

## Changes Made

### New Component
- Created `WeatherAttributionView.swift` - Reusable attribution component with two variants:
  - Standard view with background styling for prominent display
  - Compact view for space-constrained areas

### Updated Views
- **WeatherCard**: Added attribution in 5-day forecast header
- **UVIndexCard**: Added compact attribution at bottom of card  
- **ProfileView**: Added "Weather Attribution" menu item in Privacy & Legal section
  - Updated `LegalMenuItem` to support external URLs with appropriate icon

## App Store Review Context
This PR addresses the following App Store review feedback:
> **Guideline 5.2.5 - Legal - Intellectual Property**  
> The app displays Apple weather data but does not include the required Apple Weather attribution.
> Apps that support WeatherKit must clearly display the Apple Weather trademark (🍎 Weather) and legal source link.

## Test Plan
- [x] Build succeeds without errors
- [x] Attribution displays correctly on WeatherCard
- [x] Attribution displays correctly on UVIndexCard  
- [x] Profile menu item links to Apple's legal attribution page
- [x] All attribution links open https://weatherkit.apple.com/legal-attribution.html

## Screenshots
The attribution now appears as "🍎 Weather" throughout the app with proper linking to Apple's legal page.

🤖 Generated with [Claude Code](https://claude.ai/code)